### PR TITLE
Homepage polish: wider hero headline, centered intro, centered mobile collaborators, footer copy

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -47,7 +47,7 @@ const socialLinks = [
         <h3 class="footer__nav-title">Get in Touch</h3>
         <p class="footer__contact-text">
           Based in Amsterdam, Netherlands<br />
-          Available for projects worldwide
+          Available for projects worldwide.
         </p>
         <a href="/contact" class="footer__contact-link">Start a conversation</a>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -286,6 +286,16 @@ const selectedWork = selectedWorkSlugs
     max-width: 540px;
   }
 
+  @media (min-width: 1024px) {
+    .hero__content {
+      max-width: none;
+    }
+
+    .hero__title {
+      max-width: none;
+    }
+  }
+
   .hero__actions {
     display: flex;
     flex-wrap: wrap;
@@ -429,6 +439,7 @@ const selectedWork = selectedWorkSlugs
   /* Introduction */
   .intro__content {
     max-width: var(--container-content);
+    margin-inline: auto;
   }
 
   .intro__text {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -670,6 +670,19 @@ const selectedWork = selectedWorkSlugs
     scroll-snap-align: start;
   }
 
+  @media (max-width: 520px) {
+    .clients__logos {
+      scroll-snap-type: x mandatory;
+      padding-inline: calc(50vw - 110px);
+      scroll-padding-left: calc(50vw - 110px);
+      scroll-padding-right: calc(50vw - 110px);
+    }
+
+    .client-logo {
+      scroll-snap-align: center;
+    }
+  }
+
   .client-logo__img {
     display: block;
     width: 100%;


### PR DESCRIPTION
Homepage layout and small-screen carousel improvements + a minor footer copy edit.

Changes
Hero headline (desktop)
Allows H1 to span the full container width on desktop (removes max-width constraint at large breakpoints)
Intro paragraph balance
Centers the “I’ve spent twenty…” intro block within the container for a more balanced layout
Happy Collaborators carousel (mobile)
Adjusts scroll-snap and padding so the visible logo is centered when only one logo fits onscreen
Footer copy
Adds a period: Available for projects worldwide.