### PR TITLE
fix: update deploy workflow trigger from master to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '10 0 1 * *'
   workflow_dispatch:


### PR DESCRIPTION
The deploy workflow was listening for pushes to `master`, but the repo's default branch is `main`. This prevented automatic deployments after PR merges to main.

Updates the GitHub Actions workflow to trigger on pushes to main instead.

🤖 Generated with [Claude Code](https://claude.ai/code)