### PR TITLE
feat: showcase new projects and update positioning

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,12 +32,12 @@ const collaborators: CollaboratorLogo[] = fs
     src: `/images/collaborators/black/png/${filename}`,
   }));
 
-const mosaicLayout: { slug: string; size: 'lg' | 'md' | 'sm' }[] = [
+const mosaicLayout: { slug: string; size: 'lg' | 'md' | 'sm' | 'tall' }[] = [
   { slug: 'the-wild', size: 'lg' },
   { slug: 'african-puzzle', size: 'md' },
-  { slug: 'look-ma-no-hands', size: 'sm' },
-  { slug: 'scopematch', size: 'sm' },
-  { slug: 'the-usual-hotel', size: 'lg' },
+  { slug: 'look-ma-no-hands', size: 'md' },
+  { slug: 'the-usual-hotel', size: 'tall' },
+  { slug: 'scopematch', size: 'md' },
 ];
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);
 const selectedWork = mosaicLayout
@@ -799,6 +799,18 @@ const selectedWork = mosaicLayout
 
     .project-card--sm .project-card__image {
       aspect-ratio: 3 / 2;
+    }
+
+    .project-card--tall {
+      grid-column: span 7;
+      grid-row: span 2;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .project-card--tall .project-card__image {
+      aspect-ratio: auto;
+      flex: 1;
     }
 
     .services__grid {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,8 +37,6 @@ const mosaicLayout: { slug: string; size: 'lg' | 'md' | 'sm' }[] = [
   { slug: 'african-puzzle', size: 'md' },
   { slug: 'look-ma-no-hands', size: 'sm' },
   { slug: 'scopematch', size: 'sm' },
-  { slug: 'amplifon', size: 'sm' },
-  { slug: 'spook', size: 'md' },
   { slug: 'the-usual-hotel', size: 'lg' },
 ];
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);


### PR DESCRIPTION
## Summary

Add four new case studies (Look Ma No Hands, Spook, ScopeMatch, African Puzzle rewrite) while updating site content and visual hierarchy. Updates homepage positioning, typography scale, and mosaic layout to improve the Selected Work section presentation.

## Changes

- Added case studies for four self-initiated and product-focused projects
- Updated homepage copy to reflect design + product-building positioning  
- Updated About page to mention product development work
- Increased minimum font size to 16px with proportional typography rhythm
- Refreshed Selected Work mosaic: repositioned LMNH and ScopeMatch vertically with The Usual Hotel spanning 2 rows on the right
- Removed Spook and Amplifon from homepage Selected Work section
- Updated AI-friendly metadata (llms.txt, llms-full.txt) with new projects

## Notes

Includes throwaway preview HTML (public/selected-work-preview.html) from layout exploration—can be removed before merge if preferred.