### PR TITLE
fix: resolve Astro 6 build and TypeScript issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Creative consultancy driven by curiosity, led by Qa'id Jacobs from Amsterdam.
 ## Tech Stack
 
 - **Framework:** Astro 6.0.4
-- **Runtime:** Bun 1.3.3
+- **Runtime:** Bun 1.3.3 (requires Node.js >= 22.12.0 for Astro 6)
 - **TypeScript:** Strict mode (`astro/tsconfigs/strict`)
 - **Deployment:** GitHub Pages via GitHub Actions
 - **Site:** https://constellation.design
@@ -22,7 +22,7 @@ bunx astro check    # TypeScript/Astro diagnostics
 
 ## Deployment
 
-Push to `master` triggers `.github/workflows/deploy.yml`, which builds with Bun and deploys to GitHub Pages. A monthly cron also triggers redeploy. Manual dispatch is available.
+Push to `main` triggers `.github/workflows/deploy.yml`, which sets up Node.js 22 and Bun, then builds and deploys to GitHub Pages. A monthly cron also triggers redeploy. Manual dispatch is available.
 
 ## Architecture
 
@@ -194,7 +194,7 @@ When building new Astro components:
 
 ### Deployment
 
-- Branch: `master` (not `main`)
+- Branch: `main`
 - Deploy workflow: `.github/workflows/deploy.yml`
 - Build command: `bun run build`
 - Build output: `dist/`

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "typescript": "^5.9.3",
       },
       "devDependencies": {
+        "@types/node": "^25.5.0",
         "lefthook": "^1.9.0",
       },
     },
@@ -240,6 +241,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -712,6 +715,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "lefthook": "^1.9.0"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,10 +13,20 @@ echo "==> Building for production..."
 bun run build
 
 # Check for draft content leaking into dist
-if grep -r '"draft":true\|draft: true' dist/ 2>/dev/null; then
-  echo "Error: Draft content found in production build!"
+FAILED=0
+for file in src/content/projects/*.md; do
+  if grep -q "^draft: true" "$file"; then
+    slug=$(basename "$file" .md)
+    if [ -d "dist/work/$slug" ]; then
+      echo "ERROR: Draft content '$slug' found in build output"
+      FAILED=1
+    fi
+  fi
+done
+if [ "$FAILED" -eq 1 ]; then
   exit 1
 fi
+echo "    Draft content check passed"
 
 echo "==> Build complete. Output in dist/"
 echo "    Run 'bun run preview' to preview locally."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,12 +18,20 @@ fi
 BUN_VERSION=$(bun --version)
 echo "    Bun $BUN_VERSION found"
 
-# Check for Node (Astro needs it for some tooling)
+# Check for Node.js >= 22.12.0 (required by Astro 6)
 if ! command -v node &>/dev/null; then
-  echo "Warning: Node.js not found. Some Astro tooling may require it."
-else
-  echo "    Node $(node --version) found"
+  echo "Error: Node.js is not installed. Astro 6 requires Node.js >= 22.12.0."
+  exit 1
 fi
+
+NODE_VERSION=$(node --version | sed 's/^v//')
+NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+NODE_MINOR=$(echo "$NODE_VERSION" | cut -d. -f2)
+if [ "$NODE_MAJOR" -lt 22 ] || { [ "$NODE_MAJOR" -eq 22 ] && [ "$NODE_MINOR" -lt 12 ]; }; then
+  echo "Error: Node.js $NODE_VERSION found, but Astro 6 requires >= 22.12.0."
+  exit 1
+fi
+echo "    Node v$NODE_VERSION found"
 
 echo "==> Installing dependencies..."
 bun install


### PR DESCRIPTION
## Summary

Fixes the CI build failure caused by Astro 6's Node.js >= 22.12.0 requirement. The runner has Node 20, which caused the build to fail. Also resolves TypeScript errors that appeared after the upgrade.

## Changes

- Add Node.js 22 setup step to CI workflow
- Enforce Node.js >= 22.12.0 requirement in setup.sh
- Install @types/node to fix 9 TypeScript errors in index.astro
- Improve draft content check in build.sh to match CI logic

## Verification

- Local build passes with `bun run build`
- TypeScript check passes with `bunx astro check` (0 errors)
- All git hooks pass (build and typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)