### PR TITLE
Add optional website URL to case studies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Defined in `src/content.config.ts` (uses `glob()` loader):
 | `featured` | `boolean` | Default: `false` |
 | `order` | `number` | Display order, default: `0` |
 | `image` | `string` | Cover image path, e.g. `/images/work/{slug}/{slug}-cover.png` |
+| `website` | `string` (URL) | Optional — live project URL, rendered as link in snapshot card |
 | `draft` | `boolean` | Default: `false` — draft entries are excluded from production |
 
 Image convention: `/images/work/{slug}/{slug}-cover.png` and `/images/work/{slug}/{slug}-{n}.png`
@@ -127,6 +128,7 @@ industry: "Industry Name"
 featured: false
 order: 6
 image: "/images/work/{slug}/{slug}-cover.png"
+website: "https://example.com"  # Optional — live project URL
 draft: false  # Set to true to hide from production
 ---
 ```

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,6 +16,7 @@ const projectsCollection = defineCollection({
     order: z.number().default(0),
     image: z.string().optional(),
     imageFit: z.enum(['cover', 'contain']).default('cover'),
+    website: z.string().url().optional(),
     draft: z.boolean().default(false),
   }),
 });

--- a/src/content/projects/african-puzzle.md
+++ b/src/content/projects/african-puzzle.md
@@ -8,6 +8,7 @@ industry: "Productivity & Creative Tools"
 featured: true
 order: 2
 image: "/images/work/african-puzzle/african-puzzle-cover.png"
+website: "https://africanpuzzle.com/"
 draft: false
 ---
 

--- a/src/content/projects/look-ma-no-hands.md
+++ b/src/content/projects/look-ma-no-hands.md
@@ -8,6 +8,7 @@ industry: "Productivity & Developer Tools"
 featured: true
 order: 3
 image: "/images/work/look-ma-no-hands/look-ma-no-hands-cover.png"
+website: "https://qaid.github.io/look-ma-no-hands/"
 draft: false
 ---
 

--- a/src/content/projects/scopematch.md
+++ b/src/content/projects/scopematch.md
@@ -9,6 +9,7 @@ featured: false
 order: 4
 image: "/images/work/scopematch/scopematch-cover.png"
 imageFit: "contain"
+website: "https://scopematch.eu"
 draft: false
 ---
 

--- a/src/layouts/CaseStudyLayout.astro
+++ b/src/layouts/CaseStudyLayout.astro
@@ -14,6 +14,7 @@ interface Props {
   industry?: string;
   image?: string;
   imageFit?: 'cover' | 'contain';
+  website?: string;
   prevProject?: { slug: string; title: string };
   nextProject?: { slug: string; title: string };
 }
@@ -28,6 +29,7 @@ const {
   industry,
   image,
   imageFit = 'cover',
+  website,
   prevProject,
   nextProject
 } = Astro.props;
@@ -43,7 +45,8 @@ const caseStudyJsonLd: Record<string, unknown> = {
   },
   ...(client && { "publisher": { "@type": "Organization", "name": client } }),
   ...(year && { "dateCreated": year }),
-  ...(industry && { "genre": industry })
+  ...(industry && { "genre": industry }),
+  ...(website && { "url": website })
 };
 ---
 
@@ -96,6 +99,14 @@ const caseStudyJsonLd: Record<string, unknown> = {
             <div class="case-snapshot__item">
               <span class="case-snapshot__label">Industry</span>
               <span class="case-snapshot__value">{industry}</span>
+            </div>
+          )}
+          {website && (
+            <div class="case-snapshot__item">
+              <span class="case-snapshot__label">Website</span>
+              <a href={website} class="case-snapshot__value case-snapshot__link" target="_blank" rel="noopener noreferrer">
+                {new URL(website).hostname.replace('www.', '')}
+              </a>
             </div>
           )}
         </div>
@@ -445,6 +456,18 @@ const caseStudyJsonLd: Record<string, unknown> = {
     font-size: var(--font-size-xl);
     font-weight: var(--font-weight-medium);
     color: var(--color-text-primary);
+  }
+
+  a.case-snapshot__link {
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  a.case-snapshot__link:hover {
+    color: var(--color-accent-hover);
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 
   .case-hero__category {

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -29,7 +29,7 @@ interface Props {
 
 const { project, prevProject, nextProject } = Astro.props;
 const { Content } = await render(project);
-const { title, description, category, client, role, year, industry, image, imageFit } = project.data;
+const { title, description, category, client, role, year, industry, image, imageFit, website } = project.data;
 ---
 
 <CaseStudyLayout
@@ -42,6 +42,7 @@ const { title, description, category, client, role, year, industry, image, image
   industry={industry}
   image={image}
   imageFit={imageFit}
+  website={website}
   prevProject={prevProject ?? undefined}
   nextProject={nextProject ?? undefined}
 >

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -118,6 +118,8 @@
   --color-text-primary: #0A0A0A;
   --color-text-secondary: #555555;
   --color-text-muted: #888888;
+  --color-accent: #B8860B;
+  --color-accent-hover: #9A7209;
   --color-border: #E5E5E5;
   --color-border-light: #F0F0F0;
 


### PR DESCRIPTION
Adds an optional `website` field to the case studies content schema, allowing projects to declare a live URL in frontmatter. The snapshot card conditionally renders a styled "Website" link when the field is present. Includes website URLs for African Puzzle, Look Ma No Hands, and ScopeMatch; also adds the website URL to JSON-LD structured data.

**Changes:**
- Add `website` field to projects collection schema with URL validation
- Render conditional website link in case study snapshot card with theme-aware styling
- Update CLAUDE.md documentation with new field and template example
- Populate website field for three case studies

**Resolves** #33