### PR TITLE
fix: restore starfield animation blocked by CSP

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,31 +62,31 @@ const selectedWork = mosaicLayout
     <div class="hero__constellation" aria-hidden="true">
       <!-- Stars arranged in sacred geometry patterns -->
       <!-- Central triangle (pointing up) -->
-      <span class="star star--accent" data-star style="--x: 50%; --y: 25%; --size: 6px; --delay: 0s; --duration: 5s;"></span>
-      <span class="star" data-star style="--x: 35%; --y: 55%; --size: 5px; --delay: 1.2s; --duration: 4.3s;"></span>
-      <span class="star" data-star style="--x: 65%; --y: 55%; --size: 5px; --delay: 0.6s; --duration: 4.8s;"></span>
-      
+      <span class="star star--accent" data-star data-x="50%" data-y="25%" data-size="6px" data-delay="0s" data-duration="5s"></span>
+      <span class="star" data-star data-x="35%" data-y="55%" data-size="5px" data-delay="1.2s" data-duration="4.3s"></span>
+      <span class="star" data-star data-x="65%" data-y="55%" data-size="5px" data-delay="0.6s" data-duration="4.8s"></span>
+
       <!-- Outer hexagon points -->
-      <span class="star star--electric" data-star style="--x: 50%; --y: 10%; --size: 4px; --delay: 0.4s; --duration: 5.5s;"></span>
-      <span class="star" data-star style="--x: 75%; --y: 25%; --size: 4px; --delay: 2.1s; --duration: 4.8s;"></span>
-      <span class="star star--purple" data-star style="--x: 75%; --y: 55%; --size: 4px; --delay: 0.8s; --duration: 5.2s;"></span>
-      <span class="star" data-star style="--x: 50%; --y: 70%; --size: 4px; --delay: 1.5s; --duration: 4.6s;"></span>
-      <span class="star star--electric" data-star style="--x: 25%; --y: 55%; --size: 4px; --delay: 2.4s; --duration: 5.1s;"></span>
-      <span class="star" data-star style="--x: 25%; --y: 25%; --size: 4px; --delay: 0.3s; --duration: 4.4s;"></span>
-      
+      <span class="star star--electric" data-star data-x="50%" data-y="10%" data-size="4px" data-delay="0.4s" data-duration="5.5s"></span>
+      <span class="star" data-star data-x="75%" data-y="25%" data-size="4px" data-delay="2.1s" data-duration="4.8s"></span>
+      <span class="star star--purple" data-star data-x="75%" data-y="55%" data-size="4px" data-delay="0.8s" data-duration="5.2s"></span>
+      <span class="star" data-star data-x="50%" data-y="70%" data-size="4px" data-delay="1.5s" data-duration="4.6s"></span>
+      <span class="star star--electric" data-star data-x="25%" data-y="55%" data-size="4px" data-delay="2.4s" data-duration="5.1s"></span>
+      <span class="star" data-star data-x="25%" data-y="25%" data-size="4px" data-delay="0.3s" data-duration="4.4s"></span>
+
       <!-- Scattered ambient stars -->
-      <span class="star" data-star style="--x: 8%; --y: 15%; --size: 3px; --delay: 1.8s; --duration: 5.3s;"></span>
-      <span class="star star--purple" data-star style="--x: 92%; --y: 12%; --size: 3px; --delay: 0.6s; --duration: 4.7s;"></span>
-      <span class="star" data-star style="--x: 5%; --y: 45%; --size: 3px; --delay: 2.2s; --duration: 5.4s;"></span>
-      <span class="star" data-star style="--x: 95%; --y: 40%; --size: 3px; --delay: 1.1s; --duration: 4.2s;"></span>
-      <span class="star star--electric" data-star style="--x: 12%; --y: 78%; --size: 3px; --delay: 0.9s; --duration: 5.6s;"></span>
-      <span class="star" data-star style="--x: 88%; --y: 75%; --size: 3px; --delay: 2.6s; --duration: 4.5s;"></span>
-      <span class="star" data-star style="--x: 15%; --y: 92%; --size: 3px; --delay: 0.2s; --duration: 5.8s;"></span>
-      <span class="star star--purple" data-star style="--x: 85%; --y: 90%; --size: 3px; --delay: 1.4s; --duration: 4.9s;"></span>
-      <span class="star" data-star style="--x: 42%; --y: 88%; --size: 3px; --delay: 2.8s; --duration: 5.2s;"></span>
-      <span class="star" data-star style="--x: 58%; --y: 85%; --size: 3px; --delay: 0.7s; --duration: 4.1s;"></span>
-      <span class="star star--accent" data-star style="--x: 3%; --y: 65%; --size: 4px; --delay: 1.9s; --duration: 5.5s;"></span>
-      <span class="star" data-star style="--x: 97%; --y: 60%; --size: 4px; --delay: 0.5s; --duration: 4.3s;"></span>
+      <span class="star" data-star data-x="8%" data-y="15%" data-size="3px" data-delay="1.8s" data-duration="5.3s"></span>
+      <span class="star star--purple" data-star data-x="92%" data-y="12%" data-size="3px" data-delay="0.6s" data-duration="4.7s"></span>
+      <span class="star" data-star data-x="5%" data-y="45%" data-size="3px" data-delay="2.2s" data-duration="5.4s"></span>
+      <span class="star" data-star data-x="95%" data-y="40%" data-size="3px" data-delay="1.1s" data-duration="4.2s"></span>
+      <span class="star star--electric" data-star data-x="12%" data-y="78%" data-size="3px" data-delay="0.9s" data-duration="5.6s"></span>
+      <span class="star" data-star data-x="88%" data-y="75%" data-size="3px" data-delay="2.6s" data-duration="4.5s"></span>
+      <span class="star" data-star data-x="15%" data-y="92%" data-size="3px" data-delay="0.2s" data-duration="5.8s"></span>
+      <span class="star star--purple" data-star data-x="85%" data-y="90%" data-size="3px" data-delay="1.4s" data-duration="4.9s"></span>
+      <span class="star" data-star data-x="42%" data-y="88%" data-size="3px" data-delay="2.8s" data-duration="5.2s"></span>
+      <span class="star" data-star data-x="58%" data-y="85%" data-size="3px" data-delay="0.7s" data-duration="4.1s"></span>
+      <span class="star star--accent" data-star data-x="3%" data-y="65%" data-size="4px" data-delay="1.9s" data-duration="5.5s"></span>
+      <span class="star" data-star data-x="97%" data-y="60%" data-size="4px" data-delay="0.5s" data-duration="4.3s"></span>
       
       <!-- SVG for shooting pulses -->
       <svg class="shooting-stars" data-shooting-stars viewBox="0 0 100 100" preserveAspectRatio="none"></svg>
@@ -829,6 +829,15 @@ const selectedWork = mosaicLayout
 </style>
 
 <script>
+  // Apply star CSS custom properties via JS (bypasses CSP style-src restriction on inline styles)
+  document.querySelectorAll<HTMLElement>('[data-star]').forEach((star) => {
+    star.style.setProperty('--x', star.dataset.x!);
+    star.style.setProperty('--y', star.dataset.y!);
+    star.style.setProperty('--size', star.dataset.size!);
+    star.style.setProperty('--delay', star.dataset.delay!);
+    star.style.setProperty('--duration', star.dataset.duration!);
+  });
+
   // Scroll animations
   const observerOptions = {
     threshold: 0.1,
@@ -972,13 +981,10 @@ const selectedWork = mosaicLayout
     let activeStreams = 0;
 
     // Get star positions as percentages
-    const starPositions = stars.map((star) => {
-      const style = star.style;
-      return {
-        x: parseFloat(style.getPropertyValue('--x')),
-        y: parseFloat(style.getPropertyValue('--y'))
-      };
-    });
+    const starPositions = stars.map((star) => ({
+      x: parseFloat(star.dataset.x!),
+      y: parseFloat(star.dataset.y!),
+    }));
 
     // Find nearby stars for path creation
     function findNearbyStars(startIndex: number, count: number): number[] {


### PR DESCRIPTION
## Summary

Fixes issue #37: The homepage starfield animation was invisible due to Astro 6's strict CSP style-src directive blocking inline style attributes. Moved star properties to data-* attributes and apply them via JavaScript, which bypasses CSP restrictions while keeping the policy strict.

## Changes

- Replace inline `style` attributes with `data-*` attributes on 21 star elements
- Add JS initializer to apply CSS custom properties via `element.style.setProperty()`
- Update shooting stars script to read positions from data-* attributes

## Verification

- Dark mode: stars twinkling with cosmic gradient ✓
- Light mode: stars visible with adapted styling ✓
- Build: 0 errors, 0 warnings ✓
- TypeScript: 0 errors ✓
- No CSP violations ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)