### PR TITLE
Reorder case studies

### DIFF
--- a/src/content/projects/african-puzzle.md
+++ b/src/content/projects/african-puzzle.md
@@ -6,7 +6,7 @@ role: "Design Lead & Product Owner"
 year: "2024"
 industry: "Productivity & Creative Tools"
 featured: true
-order: 2
+order: 1
 image: "/images/work/african-puzzle/african-puzzle-cover.png"
 website: "https://africanpuzzle.com/"
 draft: false

--- a/src/content/projects/look-ma-no-hands.md
+++ b/src/content/projects/look-ma-no-hands.md
@@ -6,7 +6,7 @@ role: "Designer & Developer"
 year: "2025"
 industry: "Productivity & Developer Tools"
 featured: true
-order: 3
+order: 2
 image: "/images/work/look-ma-no-hands/look-ma-no-hands-cover.png"
 website: "https://qaid.github.io/look-ma-no-hands/"
 draft: false

--- a/src/content/projects/scopematch.md
+++ b/src/content/projects/scopematch.md
@@ -6,7 +6,7 @@ role: "Founder & Developer"
 year: "2025"
 industry: "Quality Assurance & Testing"
 featured: false
-order: 4
+order: 3
 image: "/images/work/scopematch/scopematch-cover.png"
 imageFit: "contain"
 website: "https://scopematch.eu"

--- a/src/content/projects/the-wild.md
+++ b/src/content/projects/the-wild.md
@@ -7,7 +7,7 @@ role: "Creative Direction"
 year: "2024"
 industry: "Publishing & Community"
 featured: true
-order: 1
+order: 4
 image: "/images/work/the-wild/the-wild-cover.png"
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,11 +32,11 @@ const collaborators: CollaboratorLogo[] = fs
   }));
 
 const mosaicLayout: { slug: string; size: 'lg' | 'md' | 'sm' | 'tall' }[] = [
-  { slug: 'the-wild', size: 'lg' },
-  { slug: 'african-puzzle', size: 'md' },
+  { slug: 'african-puzzle', size: 'lg' },
   { slug: 'look-ma-no-hands', size: 'md' },
-  { slug: 'the-usual-hotel', size: 'tall' },
   { slug: 'scopematch', size: 'md' },
+  { slug: 'the-wild', size: 'tall' },
+  { slug: 'the-usual-hotel', size: 'md' },
 ];
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);
 const selectedWork = mosaicLayout


### PR DESCRIPTION
Reorders case studies to lead with African Puzzle, followed by Look Ma No Hands, ScopeMatch, and The Wild. Updates both the project order metadata and the homepage mosaic layout to reflect the new sequence.