### PR TITLE
Remove inaccurate AI references from ScopeMatch

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -104,9 +104,9 @@ https://constellation.design/work/look-ma-no-hands
 **Year:** 2025
 **Industry:** Quality Assurance & Testing
 
-A pan-European directory of ISO 17025 accredited testing laboratories. 13,700+ labs across 6 countries with AI-powered search.
+A pan-European directory of ISO 17025 accredited testing laboratories. 13,700+ labs across 6 countries with unified search.
 
-ScopeMatch aggregates data from six national accreditation bodies (DAkkS, UKAS, COFRAC, RvA, ACCREDIA, ENAC) into one unified, searchable directory. The platform normalises test method references across countries and languages using AI-powered taxonomy classification. Founded and built by Qa'id.
+ScopeMatch aggregates data from six national accreditation bodies (DAkkS, UKAS, COFRAC, RvA, ACCREDIA, ENAC) into one unified, searchable directory. The platform normalises test method references across countries and languages using automated taxonomy classification. Founded and built by Qa'id.
 
 https://constellation.design/work/scopematch
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,7 +16,7 @@ Constellation Design partners with brands to create meaningful digital experienc
 - [The Wild](https://constellation.design/work/the-wild): Visual exploration and promotional design for The Wild Pop-up Bookstore.
 - [African Puzzle](https://constellation.design/work/african-puzzle): Design leadership and product ownership for a personal assistant app serving artisans, creatives, and entrepreneurs across 70 countries.
 - [Look Ma, No Hands](https://constellation.design/work/look-ma-no-hands): A macOS voice dictation and meeting transcription app. 100% local, privacy-first, built with WhisperKit and Core ML.
-- [ScopeMatch](https://constellation.design/work/scopematch): A pan-European directory of ISO 17025 accredited testing laboratories. 13,700+ labs across 6 countries with AI-powered search.
+- [ScopeMatch](https://constellation.design/work/scopematch): A pan-European directory of ISO 17025 accredited testing laboratories. 13,700+ labs across 6 countries with unified search.
 - [Amplifon](https://constellation.design/work/amplifon): Optimising the flows and dashboards used by audiologists to assess walk-in patients.
 - [The Usual Hotel](https://constellation.design/work/the-usual-hotel): Establishing an experience that takes hotel guests from booking online to checking in.
 - [Spook](https://constellation.design/work/spook): A lightweight macOS network traffic monitor with per-app breakdown, connection details, and traffic history.

--- a/src/content/projects/scopematch.md
+++ b/src/content/projects/scopematch.md
@@ -1,6 +1,6 @@
 ---
 title: "ScopeMatch"
-description: "A pan-European directory of ISO 17025 accredited testing laboratories. 13,700+ labs across 6 countries with AI-powered search."
+description: "A pan-European directory of ISO 17025 accredited testing laboratories. 13,700+ labs across 6 countries with unified search."
 category: "Product Strategy"
 role: "Founder & Developer"
 year: "2025"
@@ -30,12 +30,12 @@ I built ScopeMatch to fix that.
 
 The interesting problem here isn't building a search engine. It's normalization. The same tensile test might be referenced as "EN ISO 6892-1" in Germany, "BS EN ISO 6892-1" in the UK, and "NF EN ISO 6892-1" in France. Multiply that across thousands of test methods and six languages, and you have a classification problem that's genuinely hard to solve at scale.
 
-I built a data platform that aggregates lab profiles and scope data from each national accreditation body and normalizes everything into a unified taxonomy. AI-powered classification maps test method variants across borders, so a search for one finds them all. The result: 13,700+ labs with over 122,000 capability variants, all searchable from one interface.
+I built a data platform that aggregates lab profiles and scope data from each national accreditation body and normalizes everything into a unified taxonomy. Automated classification maps test method variants across borders, so a search for one finds them all. The result: 13,700+ labs with over 122,000 capability variants, all searchable from one interface.
 
 <div class="case-callout">
   <div class="case-callout__inner">
     <h3 class="case-callout__title">My Process</h3>
-    <p>From market research through architecture, data modeling, taxonomy design, AI classification, and web development. This is a solo build across the full stack. The hardest part wasn't the technology; it was the taxonomy - painstaking normalization work that makes the whole product possible.</p>
+    <p>From market research through architecture, data modeling, taxonomy design, classification, and web development. This is a solo build across the full stack. The hardest part wasn't the technology; it was the taxonomy - painstaking normalization work that makes the whole product possible.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Changes

Updates ScopeMatch case study descriptions to remove overstated AI claims:

- Changed "AI-powered search" to "unified search"
- Changed "AI-powered taxonomy classification" to "automated taxonomy classification"
- Changed "AI classification" to "classification"

## Files Modified

- `public/llms-full.txt` - Updated project summary and description
- `public/llms.txt` - Updated project summary
- `src/content/projects/scopematch.md` - Updated description and process details

These changes provide more accurate terminology for the actual technology used while maintaining the integrity of the ScopeMatch case study.